### PR TITLE
Remove debug print from ClientPlayerEntityMixins

### DIFF
--- a/src/main/java/me/vinceh121/minegasm/mixin/ClientPlayerEntityMixins.java
+++ b/src/main/java/me/vinceh121/minegasm/mixin/ClientPlayerEntityMixins.java
@@ -35,7 +35,6 @@ public class ClientPlayerEntityMixins {
 
 	@Inject(at = @At("HEAD"), method = "requestRespawn()V")
 	private void onRespawn(CallbackInfo ci) {
-		Minegasm.LOGGER.info("u've wespawnyed uwu ᗜˬᗜ");
 		ClientEventHandler.onRespawn();
 	}
 }

--- a/src/main/java/me/vinceh121/minegasm/mixin/ClientPlayerEntityMixins.java
+++ b/src/main/java/me/vinceh121/minegasm/mixin/ClientPlayerEntityMixins.java
@@ -1,5 +1,6 @@
 package me.vinceh121.minegasm.mixin;
 
+import com.therainbowville.minegasm.common.Minegasm;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -34,7 +35,7 @@ public class ClientPlayerEntityMixins {
 
 	@Inject(at = @At("HEAD"), method = "requestRespawn()V")
 	private void onRespawn(CallbackInfo ci) {
-		System.out.println("respawn owo");
+		Minegasm.LOGGER.info("u've wespawnyed uwu ᗜˬᗜ");
 		ClientEventHandler.onRespawn();
 	}
 }


### PR DESCRIPTION
I'd recommend removing or using the logger for anything pushed with `System.out.println()` 🙂 